### PR TITLE
fix the bug that input('param.') contains the parameter values of pre…

### DIFF
--- a/src/_shims/sl_handler.php
+++ b/src/_shims/sl_handler.php
@@ -55,7 +55,9 @@ function handler($event, $context)
     $_GET = json_decode(json_encode($_GET), true);
 
     $_SERVER['REQUEST_METHOD'] = $event->httpMethod;
-
+	
+	$_POST = array();
+	
     if(!empty($event->body)) {
       $jsonobj = json_decode($event->body, true);
       if (is_array($jsonobj) && !empty($jsonobj)) {


### PR DESCRIPTION
…vious request